### PR TITLE
Let's see if we can kick off a Dependabot version update check ...

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"


### PR DESCRIPTION
I'm not sure if this works, but I wonder if [configuring a specific time](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday) is a good way to kick off a version-update check 🤷‍♂️